### PR TITLE
recording to wav

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = space
+indent_size = 2

--- a/packages/core/src/audioview.js
+++ b/packages/core/src/audioview.js
@@ -46,6 +46,9 @@ if (match) {
 
 // console.log("workletUrl", workletUrl);
 
+import recorderUrl from "./recorder.js?worker&url";
+import { audioBuffersToWav } from "./wav.js";
+
 export class AudioView {
   constructor() {}
   async updateGraph(node) {
@@ -119,6 +122,7 @@ export class AudioView {
     }
 
     await this.audioCtx.audioWorklet.addModule(workletUrl);
+    await this.audioCtx.audioWorklet.addModule(recorderUrl);
 
     this.audioWorklet = new AudioWorkletNode(
       this.audioCtx,
@@ -136,12 +140,34 @@ export class AudioView {
         setTimeout(() => this.destroy(), msg.data.fadeTime * 1000 + lash);
       }
     };
-    this.audioWorklet.connect(this.audioCtx.destination);
+
+    this.recorder = new window.AudioWorkletNode(this.audioCtx, 'recorder');
+    this.audioWorklet.connect(this.recorder);
+    this.recorder.connect(this.audioCtx.destination);
+
+    this.recorder.port.onmessage = (e) => {
+      if (e.data.eventType === 'data') {
+        this.recordedBuffers.push(e.data.audioBuffer);
+      }
+      if (e.data.eventType === 'stop') {
+        console.log("recording stopped");
+        const bytes = audioBuffersToWav(this.recordedBuffers, this.audioCtx.sampleRate, 2);
+        const blob = new Blob([bytes], {type: "audio/wav"});
+        const link = document.createElement('a');
+        link.href = window.URL.createObjectURL(blob);
+        link.download = "kabelsalat.wav";
+        link.click();
+        this.recordedBuffers = [];
+      }
+    };
   }
 
   destroy() {
     this.audioWorklet?.disconnect();
     this.audioWorklet = null;
+
+    this.recorder?.disconnect();
+    this.recorder = null;
 
     this.audioCtx?.close();
     this.audioCtx = null;
@@ -152,6 +178,24 @@ export class AudioView {
    */
   stop() {
     this.audioCtx && this.send({ type: "STOP" });
+  }
+
+  record() {
+    if (!this.audioCtx) {
+      return;
+    }
+
+    this.recordedBuffers = [];
+    this.recorder.parameters.get('isRecording').setValueAtTime(1, 0);
+    console.log("recording started");
+  }
+
+  stopRecording() {
+    if (!this.audioCtx) {
+      return;
+    }
+
+    this.recorder.parameters.get('isRecording').setValueAtTime(0, 0);
   }
 
   set fadeTime(fadeTime) {

--- a/packages/core/src/audioview.js
+++ b/packages/core/src/audioview.js
@@ -152,11 +152,7 @@ export class AudioView {
       if (e.data.eventType === 'stop') {
         console.log("recording stopped");
         const bytes = audioBuffersToWav(this.recordedBuffers, this.audioCtx.sampleRate, 2);
-        const blob = new Blob([bytes], {type: "audio/wav"});
-        const link = document.createElement('a');
-        link.href = window.URL.createObjectURL(blob);
-        link.download = "kabelsalat.wav";
-        link.click();
+        this.downloadFile(bytes, "kabelsalat.wav", "audio/wav");
         this.recordedBuffers = [];
       }
     };
@@ -196,6 +192,14 @@ export class AudioView {
     }
 
     this.recorder.parameters.get('isRecording').setValueAtTime(0, 0);
+  }
+
+  downloadFile(bytes, filename, mimeType) {
+    const blob = new Blob([bytes], {type: mimeType});
+    const link = document.createElement('a');
+    link.href = window.URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
   }
 
   set fadeTime(fadeTime) {

--- a/packages/core/src/recorder.js
+++ b/packages/core/src/recorder.js
@@ -1,0 +1,88 @@
+// based on https://gist.githubusercontent.com/flpvsk/047140b31c968001dc563998f7440cc1/raw/cc7e9681cd5ad88a8edcfcdcb218a3d7d4af9c2b/recorderWorkletProcessor.js
+
+class RecorderWorklet extends AudioWorkletProcessor {
+  static get parameterDescriptors() {
+    return [{
+      name: 'isRecording',
+      defaultValue: 0
+    }];
+  }
+
+  constructor() {
+    super();
+    this._bufferSize = 2048;
+    this._buffer = new Float32Array(this._bufferSize);
+    this._initBuffer();
+  }
+
+  _initBuffer() {
+    this._bytesWritten = 0;
+  }
+
+  _isBufferEmpty() {
+    return this._bytesWritten === 0;
+  }
+
+  _isBufferFull() {
+    return this._bytesWritten === this._bufferSize;
+  }
+
+  _appendToBuffer(value) {
+    if (this._isBufferFull()) {
+      this._flush();
+    }
+
+    this._buffer[this._bytesWritten] = value;
+    this._bytesWritten += 1;
+  }
+
+  _flush() {
+    let buffer = this._buffer;
+    if (this._bytesWritten < this._bufferSize) {
+      buffer = buffer.slice(0, this._bytesWritten);
+    }
+
+    this.port.postMessage({
+      eventType: 'data',
+      audioBuffer: buffer
+    });
+
+    this._initBuffer();
+  }
+
+  _recordingStopped() {
+    this.port.postMessage({
+      eventType: 'stop'
+    });
+  }
+
+  process(inputs, outputs, parameters) {
+    const isRecordingValues = parameters.isRecording;
+
+    const output = outputs[0];
+    const input = inputs[0];
+    const outChannel0 = output[0];
+    const outChannel1 = output[1];
+
+    for (let i = 0; i < isRecordingValues.length; i++) {
+      const shouldRecord = isRecordingValues[i] === 1;
+      if (!shouldRecord && !this._isBufferEmpty()) {
+        this._flush();
+        this._recordingStopped();
+      }
+
+      if (shouldRecord) {
+        this._appendToBuffer(input[0][i]);
+        this._appendToBuffer(input[1][i]);
+      }
+
+      outChannel0[i] = input[0][i];
+      outChannel1[i] = input[1][i];
+    }
+
+    return true;
+  }
+
+}
+
+registerProcessor('recorder', RecorderWorklet);

--- a/packages/core/src/wav.js
+++ b/packages/core/src/wav.js
@@ -1,0 +1,67 @@
+// based on https://github.com/Experience-Monks/audiobuffer-to-wav
+
+export function audioBuffersToWav(buffers, sampleRate, numChannels) {
+  if (buffers.length < 1) {
+    return undefined;
+  }
+
+  const firstBuffer = buffers[0];
+  const format = 3;
+  const bitDepth = 32;
+
+  const numSamples = buffers.map(buf => buf.length)
+        .reduce((a,b) => a+b, 0);
+
+  const bytesPerSample = bitDepth / 8;
+  const blockAlign = numChannels * bytesPerSample;
+
+  const headerSize = 44;
+  const outputBuffer = new ArrayBuffer(headerSize + numSamples * bytesPerSample);
+  const view = new DataView(outputBuffer);
+
+  /* RIFF identifier */
+  writeString(view, 0, 'RIFF');
+  /* RIFF chunk length */
+  view.setUint32(4, 36 + numSamples * bytesPerSample, true);
+  /* RIFF type */
+  writeString(view, 8, 'WAVE');
+  /* format chunk identifier */
+  writeString(view, 12, 'fmt ');
+  /* format chunk length */
+  view.setUint32(16, 16, true);
+  /* sample format (raw) */
+  view.setUint16(20, format, true);
+  /* channel count */
+  view.setUint16(22, numChannels, true);
+  /* sample rate */
+  view.setUint32(24, sampleRate, true);
+  /* byte rate (sample rate * block align) */
+  view.setUint32(28, sampleRate * blockAlign, true);
+  /* block align (channel count * bytes per sample) */
+  view.setUint16(32, blockAlign, true);
+  /* bits per sample */
+  view.setUint16(34, bitDepth, true);
+  /* data chunk identifier */
+  writeString(view, 36, 'data');
+  /* data chunk length */
+  view.setUint32(40, numSamples * bytesPerSample, true);
+  let bufferOffset = 44;
+  for (const buffer of buffers) {
+    writeFloat32(view, bufferOffset, buffer);
+    bufferOffset += buffer.length * bytesPerSample;
+  }
+
+  return outputBuffer;
+}
+
+function writeString(view, offset, string) {
+  for (let i = 0; i < string.length; i++) {
+    view.setUint8(offset + i, string.charCodeAt(i));
+  }
+}
+
+function writeFloat32(view, offset, input) {
+  for (var i = 0; i < input.length; i++, offset += 4) {
+    view.setFloat32(offset, input[i], true);
+  }
+}

--- a/packages/lib/src/repl.js
+++ b/packages/lib/src/repl.js
@@ -5,9 +5,10 @@ import * as lib from "./lib.js";
 import { transpiler } from "@kabelsalat/transpiler";
 
 export class SalatRepl {
-  constructor({ onToggle, beforeEval } = {}) {
+  constructor({ onToggle, onToggleRecording, beforeEval } = {}) {
     this.audio = new AudioView();
     this.onToggle = onToggle;
+    this.onToggleRecording = onToggleRecording;
     this.beforeEval = beforeEval;
     if (typeof window !== "undefined") {
       Object.assign(globalThis, core);
@@ -40,5 +41,13 @@ export class SalatRepl {
   stop() {
     this.audio.stop();
     this.onToggle?.(false);
+  }
+  record() {
+    this.audio.record();
+    this.onToggleRecording?.(true);
+  }
+  stopRecording() {
+    this.audio.stopRecording();
+    this.onToggleRecording?.(false);
   }
 }

--- a/website/src/components/Repl.jsx
+++ b/website/src/components/Repl.jsx
@@ -83,8 +83,10 @@ function updateCode(code) {
 
 export function Repl() {
   let [started, setStarted] = createSignal(false);
+  let [recording, setRecording] = createSignal(false);
   const repl = new SalatRepl({
     onToggle: (_started) => setStarted(_started),
+    onToggleRecording: (_recording) => setRecording(_recording),
     beforeEval: (transpiled) => {
       updateWidgets(codemirrorView(), transpiled.widgets);
     },
@@ -151,6 +153,22 @@ export function Repl() {
               <>
                 <Icon type="stop" />
                 <span class="hidden sm:block">stop</span>
+              </>
+            )}
+          </button>
+          <button
+            onClick={() => (recording() ? repl.stopRecording() : repl.record())}
+            class="items-center flex space-x-1 hover:opacity-50"
+          >
+            {!recording() ? (
+              <>
+                <Icon type="play" />
+                <span class="animate-pulse hidden sm:block">record</span>
+              </>
+            ) : (
+              <>
+                <Icon type="stop" />
+                <span class="hidden sm:block">stop recording</span>
               </>
             )}
           </button>


### PR DESCRIPTION
adds a new `RecorderWorklet` that sits between the `GraphWorklet` and the output, plus a new button in the UI to toggle recording. when recording ends, the recorded audio is encoded as a WAV file, which is then downloaded by the browser.

this is a proof of concept with a few issues still:

- the record button really only works correctly when clicked after playback has started.
  - what should happen if it is clicked while playback is stopped? options include auto-starting playback, or "arm for recording" behavior (set a flag that will start recording immediately on play).
- i didnt put a lot of thought into where various pieces of code should go yet, e.g. `downloadFile()` being a method of `AudioView` probably doesnt make sense.
- the record button needs an icon.
- need to test in more browsers - at least Firefox/macOS works.
- buttons now shift around because the labels "record" and "stop recording" have different lengths, maybe there is a better labeling scheme... :)

and some things that maybe dont need to be addressed in this first iteration, but are worth thinking about:

- the `RecorderWorklet` is now always running, but when recording is disabled, it just copies input to output. would removing it from the chain when unused have any meaningful performance impact? (my brief testing suggests the overhead is negligible)
- long recordings will consume a lot of memory, a more refined implementation could maybe do periodic flushes to localStorage or something.