### PR TITLE
Feedback registers

### DIFF
--- a/packages/cli/src/clib/ugens.c
+++ b/packages/cli/src/clib/ugens.c
@@ -348,33 +348,6 @@ void *Delay_create()
   return (void *)node;
 }
 
-typedef struct Feedback
-{
-  double value;
-} Feedback;
-
-void Feedback_init(Feedback *self)
-{
-  self->value = 0;
-}
-
-double Feedback_write(Feedback *self, double value)
-{
-  self->value = value;
-  return 0;
-}
-double Feedback_update(Feedback *self)
-{
-  return self->value;
-}
-
-void *Feedback_create()
-{
-  Feedback *node = (Feedback *)malloc(sizeof(Feedback));
-  Feedback_init(node);
-  return (void *)node;
-}
-
 // Output
 
 typedef struct Output
@@ -387,12 +360,13 @@ void Output_init(Output *self)
   self->value = 0;
 }
 
-double Output_update(Feedback *self, double value)
+// TODO: find out what to do with id
+double Output_update(Output *self, double value, int id)
 {
   self->value = value;
   return self->value;
 }
-double Output_read(Feedback *self)
+double Output_read(Output *self)
 {
   return self->value;
 }

--- a/packages/cli/src/ks2c.js
+++ b/packages/cli/src/ks2c.js
@@ -79,6 +79,7 @@ ${unit.ugens
 
   double time = 0.0;
   float buffer[BUFFER_SIZE];
+  float r[${unit.registers}] = {0};
   while (1)
   {
     for (size_t j = 0; j < BUFFER_SIZE; j+=2)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,5 +7,5 @@ This package contains the core components of kabelsalat:
 
 Notable features:
 
-- feedback resolution: graph cycles are broken up into feedback_read and feedback_write nodes
+- single sample feedback: graph cycles will feed back to the next sample
 - multichannel-expansion: Passing an Array (or poly node) to an input will split the graph (similar to SuperCollider)

--- a/packages/core/src/compiler.js
+++ b/packages/core/src/compiler.js
@@ -6,14 +6,14 @@ export function compile(node, options = {}) {
     lang = "js",
     fallbackType = "thru",
     constType = "n",
-    varPrefix = "n",
+    getRegister = (id) => `r[${id}]`,
   } = options;
   log && console.log("compile", node);
   const nodes = topoSort(node);
   let lines = [];
   let v = (id) => {
     if (nodes[id].type !== constType) {
-      return `${varPrefix}${id}`;
+      return getRegister(id);
     }
     if (typeof nodes[id].value === "string") {
       return `"${nodes[id].value}"`;
@@ -57,11 +57,11 @@ export function compile(node, options = {}) {
     console.log("compiled code:");
     console.log(src);
   }
-  return { src, ugens };
+  return { src, ugens, registers: nodes.length };
 }
 
 Node.prototype.compile = function (options) {
-  return compile(this.dagify(), options);
+  return compile(this, options);
 };
 
 // simple topo sort using dfs

--- a/packages/core/src/compiler.js
+++ b/packages/core/src/compiler.js
@@ -43,6 +43,7 @@ export function compile(node, options = {}) {
       ugen: schema.ugen,
       name: v(id),
       lang,
+      getRegister,
     };
     if (schema.compile) {
       lines.push(schema.compile(meta));

--- a/packages/core/src/graph.js
+++ b/packages/core/src/graph.js
@@ -53,7 +53,7 @@ Node.prototype.stringify = function () {
   return JSON.stringify(this, null, 2).replaceAll('"', "'");
 };
 
-function getNode(type, ...args) {
+export function getNode(type, ...args) {
   let maxExpansions = 1;
   args = args.map((arg) => {
     // desugar array to poly node
@@ -267,6 +267,13 @@ Node.prototype.map = function (fn) {
     return fn(this);
   }
   return poly(...this.ins.map(fn));
+};
+
+Node.prototype.channel = function (ch) {
+  if (this.type !== "poly") {
+    return this;
+  }
+  return this.ins[ch % this.ins.length];
 };
 
 nodeRegistry.set("select", {

--- a/packages/core/src/graph.js
+++ b/packages/core/src/graph.js
@@ -201,12 +201,8 @@ export function n(value) {
 
 nodeRegistry.set("out", {
   tags: ["meta"],
-  description: "Sends the node to the audio output (dac)",
+  description: "Sends the node to the audio output",
 });
-// this method will be overriden when using evaluate
-Node.prototype.out = function () {
-  return dac(this);
-};
 
 nodeRegistry.set("withIns", {
   internal: true,

--- a/packages/graphviz/src/graphviz.js
+++ b/packages/graphviz/src/graphviz.js
@@ -9,17 +9,12 @@ Node.prototype.render = async function (container, options = {}) {
     return;
   }
   const {
-    dagify = false, // if true, cycles will be transformed to feedback nodes
     resolveModules = false, // if false, module innards are ignored
     inlineNumerics = true,
     rankdir = "TB",
     size = 0,
   } = options;
   let node = this;
-
-  if (dagify) {
-    this.dagify();
-  }
 
   let getNumericLabel = (value) =>
     Math.trunc(value) === value ? value : value.toFixed(2);

--- a/packages/lib/src/audiograph.js
+++ b/packages/lib/src/audiograph.js
@@ -118,7 +118,7 @@ export class AudioGraph {
     for (let i = 0; i < this.units.length; i++) {
       const unit = this.units[i];
       const lvl = unit.getLevel(this.playPos);
-      unit.genSample(this.playPos, unit.nodes, inputs);
+      unit.genSample(this.playPos, unit.nodes, inputs, unit.registers);
       sum[0] += unit.getOutput(0) * lvl;
       sum[1] += unit.getOutput(1) * lvl;
     }
@@ -177,8 +177,9 @@ class Unit {
       this.nodes[i].source = this.nodes[outputIndex];
     });
     // could potentially warn about outputs that have no corresponding inputs and ignore them?
-
-    this.genSample = new Function("time", "nodes", "input", schema.src);
+    // initialize empty registers
+    this.registers = new Array(schema.registers).fill(0);
+    this.genSample = new Function("time", "nodes", "input", "r", schema.src);
   }
 
   getOutput(index) {

--- a/packages/lib/src/audiograph.js
+++ b/packages/lib/src/audiograph.js
@@ -165,17 +165,6 @@ class Unit {
       this.outputs[channel] = this.nodes[i];
     }
 
-    // this logic could also be moved to the compiler..
-    // assign corresponding output nodes to input nodes
-    schema.ugens.forEach((ugen, i) => {
-      if (ugen.type !== "Source") {
-        return;
-      }
-      const outputIndex = schema.ugens.findIndex(
-        (node) => node.type === "Output" && node.inputs[1] === ugen.inputs[0]
-      );
-      this.nodes[i].source = this.nodes[outputIndex];
-    });
     // could potentially warn about outputs that have no corresponding inputs and ignore them?
     // initialize empty registers
     this.registers = new Array(schema.registers).fill(0);

--- a/packages/lib/src/lang/c.js
+++ b/packages/lib/src/lang/c.js
@@ -1,7 +1,7 @@
 export let defSin = (input) => `sin(${input})`;
 export let defCos = (input) => `cos(${input})`;
 export let def = (name, value, comment) =>
-  `float ${name} = ${value};${comment ? ` /* ${comment} */` : ""}`;
+  `${name} = ${value};${comment ? ` /* ${comment} */` : ""}`;
 
 export let defUgen = (meta, ...args) => {
   args.unshift(`nodes[${meta.ugenIndex}]`);

--- a/packages/lib/src/lang/js.js
+++ b/packages/lib/src/lang/js.js
@@ -1,7 +1,7 @@
 export let defSin = (input) => `Math.sin(${input})`;
 export let defCos = (input) => `Math.cos(${input})`;
 export let def = (name, value, comment) =>
-  `const ${name} = ${value};${comment ? ` /* ${comment} */` : ""}`;
+  `${name} = ${value};${comment ? ` /* ${comment} */` : ""}`;
 
 export let defUgen = (meta, ...args) => {
   return def(

--- a/packages/lib/src/lib.js
+++ b/packages/lib/src/lib.js
@@ -322,34 +322,6 @@ export let lag = registerNode("lag", {
     langs[meta.lang].defUgen(meta, input, rate),
 });
 
-// feedback_write doesn't need a creation function, because it's created internally in dagify
-nodeRegistry.set("feedback_write", {
-  internal: true,
-  tags: ["innards"],
-  description: "Writes to the feedback buffer. Not intended for direct use",
-  compile: ({ vars, node, name, lang }) =>
-    langs[lang].def(
-      name,
-      langs[lang].feedbackWrite(node.to, vars[0]),
-      "feedback_write"
-    ),
-});
-export let feedback_read = registerNode("feedback_read", {
-  ugen: "Feedback",
-  internal: true,
-  description: "internal helper node to read the last feedback_write output",
-  ins: [],
-  compile: ({ vars, ...meta }) => {
-    const { nodes, id, ugenIndex } = meta;
-    // remap indices
-    // we need to rewrite the "to" value to the audio node index (instead of flat node index)
-    const writer = nodes.find(
-      (node) => node.type === "feedback_write" && node.to === nodes[id]
-    );
-    writer.to = ugenIndex;
-    return langs[meta.lang].defUgen(meta, ...vars);
-  },
-});
 export let slew = registerNode("slew", {
   ugen: "Slew",
   tags: ["fx"],

--- a/packages/lib/src/ugens.js
+++ b/packages/lib/src/ugens.js
@@ -223,15 +223,6 @@ export class Output {
   }
 }
 
-export class Source {
-  constructor() {
-    this.source = { value: 0 }; // fallback
-  }
-  update() {
-    return this.source.value;
-  }
-}
-
 /**
  * White noise source
  */

--- a/packages/lib/src/ugens.js
+++ b/packages/lib/src/ugens.js
@@ -213,21 +213,6 @@ export class Hold extends AudioNode {
   }
 }
 
-export class Feedback extends AudioNode {
-  constructor(id, state, sampleRate, send) {
-    super(id, state, sampleRate, send);
-    this.value = 0;
-  }
-  write(value) {
-    this.value = value;
-    return 0;
-  }
-
-  update() {
-    return this.value;
-  }
-}
-
 export class Output {
   constructor() {
     this.value = 0;

--- a/packages/web/src/audioview.js
+++ b/packages/web/src/audioview.js
@@ -56,7 +56,7 @@ export class AudioView {
     this.ugens = new Map();
   }
   async updateGraph(node) {
-    const { src, ugens } = node.compile({
+    const { src, ugens, registers } = node.compile({
       log: false,
     });
     this.initMouse();
@@ -72,7 +72,7 @@ export class AudioView {
     this.sendUgens();
     this.send({
       type: "NEW_UNIT",
-      unit: { src, ugens },
+      unit: { src, ugens, registers },
     });
   }
 

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -7,40 +7,31 @@ Object.assign(globalThis, lib);
 
 describe("compiler", () => {
   it("sine", () => {
-    const unit = sine(200).out().exit().compile();
+    const unit = sine(200).output(0).exit().compile();
     expect(unit.src).toStrictEqual(
-      `const n1 = nodes[0].update(200,0,0); /* sine */
-return [(n1*lvl),(n1*lvl)]`
-      // this is what happened with khans algorithm (bfs):
-      //`const n2 = nodes[0].update(200,0,0); /* sine */
-      //return [(n2*lvl),(n2*lvl)]`
+      `r[1] = nodes[0].update(200,0,0); /* sine */
+r[3] = nodes[1].update(r[1],0); /* output */`
     );
-    expect(unit.ugens.map((ugen) => ugen.type)).toStrictEqual(["SineOsc"]);
+    expect(unit.ugens.map((ugen) => ugen.type)).toStrictEqual([
+      "SineOsc",
+      "Output",
+    ]);
   });
   it("feedback", () => {
     const unit = sine(200)
       .add((x) => x.mul(0.8))
-      .out()
+      .output(1)
       .exit()
       .compile();
     expect(unit.src).toStrictEqual(
-      `const n1 = nodes[0].update(200,0,0); /* sine */
-const n2 = nodes[1].update(); /* feedback_read */
-const n3 = n1 + n2;
-const n5 = n3 * 0.8;
-const n6 = nodes[1].write(n5); /* feedback_write */
-return [(n3*lvl),(n3*lvl)]`
-      // this is what happened with khans algorithm (bfs):
-      //`const n5 = nodes[0].update(); /* feedback_read */
-      //const n3 = nodes[1].update(200,0,0); /* sine */
-      //const n2 = n3 + n5;
-      //const n7 = n2 * 0.8;
-      //const n6 = nodes[0].write(n7); /* feedback_write */
-      //return [(n2*lvl),(n2*lvl)]`
+      `r[1] = nodes[0].update(200,0,0); /* sine */
+r[3] = r[4] * 0.8;
+r[4] = r[1] + r[3];
+r[6] = nodes[1].update(r[4],1); /* output */`
     );
     expect(unit.ugens.map((ugen) => ugen.type)).toStrictEqual([
       "SineOsc",
-      "Feedback",
+      "Output",
     ]);
   });
 });

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -20,25 +20,27 @@ describe("Node", () => {
     expect(id(n(1))).toStrictEqual(n(1));
     expect(n(1).id()).toStrictEqual(n(1));
   });
-  test("loopsToMe", () => {
-    const fb = n(1);
-    expect(fb.loopsToMe(fb)).toStrictEqual(true);
-    let inner;
-    let fb2 = add((x) => {
-      inner = x.mul(1);
-      return inner;
+  test("output", () => {
+    const node = sine(200).output(1);
+    expect(node.toObject()).toStrictEqual({
+      type: "output",
+      ins: [
+        { type: "sine", ins: [{ type: "n", value: 200, ins: [] }] },
+        {
+          type: "n",
+          value: 1,
+          ins: [],
+        },
+      ],
     });
-    expect(fb2.loopsToMe(inner)).toStrictEqual(true);
-    let fb3 = add((x) => x);
-    expect(fb3.loopsToMe(fb3)).toStrictEqual(true);
   });
   test("evaluate", () => {
     const node = evaluate("sine(200).out()");
     expect(node.toObject()).toStrictEqual({
-      type: "exit", // <- this is the node all connect to (to make feedback_write nodes discoverable)
+      type: "exit",
       ins: [
         {
-          type: "dac", // <- this is the node that only sound generators connect to
+          type: "output",
           ins: [
             {
               type: "sine",
@@ -49,6 +51,31 @@ describe("Node", () => {
                   ins: [],
                 },
               ],
+            },
+            {
+              ins: [],
+              type: "n",
+              value: 0,
+            },
+          ],
+        },
+        {
+          type: "output",
+          ins: [
+            {
+              ins: [
+                {
+                  ins: [],
+                  type: "n",
+                  value: 200,
+                },
+              ],
+              type: "sine",
+            },
+            {
+              ins: [],
+              type: "n",
+              value: 1,
             },
           ],
         },

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -32,32 +32,6 @@ describe("Node", () => {
     let fb3 = add((x) => x);
     expect(fb3.loopsToMe(fb3)).toStrictEqual(true);
   });
-  test("dagify", () => {
-    const fb = add((x) => x).exit();
-    expect(fb.dagify().flatten()).toStrictEqual([
-      // 0
-      {
-        type: "exit",
-        ins: ["1", "2"],
-      },
-      // 1
-      {
-        type: "feedback_write",
-        ins: ["2"],
-        to: 3,
-      },
-      // 2
-      {
-        type: "add",
-        ins: ["3"],
-      },
-      // 3
-      {
-        type: "feedback_read",
-        ins: [],
-      },
-    ]);
-  });
   test("evaluate", () => {
     const node = evaluate("sine(200).out()");
     expect(node.toObject()).toStrictEqual({

--- a/website/src/components/MiniRepl.jsx
+++ b/website/src/components/MiniRepl.jsx
@@ -5,7 +5,6 @@ import { Icon } from "./Icon";
 
 let vizSettings = {
   resolveModules: false,
-  dagify: false,
   rankdir: "LR",
   size: 12,
 };

--- a/website/src/components/Repl.jsx
+++ b/website/src/components/Repl.jsx
@@ -47,7 +47,7 @@ note
 .mul(.5) // master level
 .out() // send to output`;
 
-let vizSettings = { resolveModules: false, dagify: false };
+let vizSettings = { resolveModules: false };
 
 let TAB_GRAPH = "graph";
 let TAB_DOCS = "docs";


### PR DESCRIPTION
I realized feedback could be implemented in a much simpler way: Instead of defining new variables within the compiled function, each node could consume its inputs by reading from a registry that is created at compile time. when a node is updated, it writes to its register. This means we can reference nodes from a previous render without going into ReferenceError's. It also means we don't need Feedback Ugens. It works because the dfs based topoSort tolerates cycles (it will stop when it finds a visited node).