### PR TITLE
Binary Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 
 doc.json
 nanokabel
+
+bin

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ pnpm --filter "./packages/**" publish --dry-run
 pnpm --filter "./packages/**" publish --access public
 ```
 
+## Experimental "Desktop" Version
+
+There is an experimental "Desktop" version, which serves the built site as a binary (<10MB).
+It's without UI, so you still have to open it in your browser, but it's self-contained, so it works offline and all code is baked into the binary.
+
+```sh
+pnpm build # build site to website/dist
+# make sure you have go installed
+pnpm build-bin # builds all binaries
+./bin/kabelsalat-darwin-arm64 # run site
+# go to http://localhost:8080
+```
+
+Currently it builds Linux and MacOS binaries, but adding others should be trivial.
+
 ## Packages
 
 This project is a monorepo with the following packages:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module server
+
+go 1.23.2

--- a/kabelsalat.go
+++ b/kabelsalat.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"embed"
+	"io/fs"
+	"log"
+	"net/http"
+)
+
+//go:embed website/dist/*
+var files embed.FS
+
+func main() {
+	publicFiles, err := fs.Sub(files, "website/dist")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fs := http.FileServer(http.FS(publicFiles))
+
+	http.Handle("/", fs)
+	log.Println("Serving files on http://localhost:8080")
+	err = http.ListenAndServe(":8080", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "cd website && pnpm dev",
     "build": "cd website && pnpm build",
     "preview": "cd website && pnpm preview",
-    "test": "cd test && pnpm test"
+    "test": "cd test && pnpm test",
+    "build-darwin-arm64": "GOOS=darwin GOARCH=arm64 go build -o bin/kabelsalat-darwin-arm64",
+    "build-darwin-amd64": "GOOS=darwin GOARCH=amd64 go build -o bin/kabelsalat-darwin-amd64",
+    "build-linux-amd64": "GOOS=linux GOARCH=amd64 go build -o bin/kabelsalat-linux-amd64",
+    "build-bin": "npm run build-darwin-arm64 && npm run build-linux-amd64"
   },
   "author": "Felix Roos <flix91@gmail.com>",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
This is an experimental "Desktop" version, which serves the built site as a binary (<10MB).
It's without UI, so you still have to open it in your browser, but it's self-contained, so it works offline and all code is baked into the binary.

```sh
pnpm build # build site to website/dist
# make sure you have go installed
pnpm build-bin # builds all binaries
./bin/kabelsalat-darwin-arm64 # run site
# go to http://localhost:8080
```

Currently it builds Linux and MacOS binaries, but adding others should be trivial.