### PR TITLE
message scheduling + packaging improvements

### DIFF
--- a/packages/core/src/graph.js
+++ b/packages/core/src/graph.js
@@ -340,13 +340,20 @@ function flatten(node) {
   });
 }
 
-export function evaluate(code) {
-  // make sure to call Object.assign(globalThis, api);
+export let exit = registerNode("exit", { internal: true });
+
+export function evaluate(code, scope) {
   let nodes = [];
   Node.prototype.out = function (channels = [0, 1]) {
     nodes.push(this.output(channels));
   };
-  Function(code)();
+  if (scope) {
+    // pass all members of scope as function arguments to avoid using global scope
+    Function(...Object.keys(scope), code)(...Object.values(scope));
+  } else {
+    // expect scope to be assigned to globalThis
+    Function(code)();
+  }
   const node = exit(...nodes);
   return node;
 }

--- a/packages/lib/src/audiograph.js
+++ b/packages/lib/src/audiograph.js
@@ -18,6 +18,7 @@ export class AudioGraph {
     this.send = send;
     this.units = [];
     this.fadeTime = 0.1;
+    this.q = []; // scheduler queue
   }
 
   fadeOutLastUnit() {
@@ -89,6 +90,9 @@ export class AudioGraph {
       case "SET_UGEN":
         this.addUgen(msg.className, msg.ugen);
         break;
+      case "SCHEDULE_MSG":
+        this.scheduleMessage(msg);
+        break;
 
       default:
         throw new TypeError(`unknown message type ${msg.type}`);
@@ -107,6 +111,24 @@ export class AudioGraph {
     this.units.forEach((unit) => unit.setControl(msg));
   }
 
+  // scheduledMessage: {msg, time}
+  scheduleMessage(msg) {
+    msg.time = this.playPos + msg.time;
+    if (!this.q.length) {
+      // if empty, just push
+      this.q.push(msg);
+      return;
+    }
+    // not empty
+    // find index where msg.time fits in
+    let i = 0;
+    while (i < this.q.length && this.q[i].time < msg.time) {
+      i++;
+    }
+    // this ensures q stays sorted by time, so we only need to check q[0]
+    this.q.splice(i, 0, msg);
+  }
+
   /**
    * Generate one [left, right] pair of audio samples
    */
@@ -116,6 +138,11 @@ export class AudioGraph {
 
     const sum = [0, 0];
     for (let i = 0; i < this.units.length; i++) {
+      while (this.q.length > 0 && this.q[0].time <= this.playPos) {
+        // trigger due messages. q is sorted, so we only need to check q[0]
+        this.parseMsg(this.q[0].msg);
+        this.q.shift();
+      }
       const unit = this.units[i];
       const lvl = unit.getLevel(this.playPos);
       unit.genSample(

--- a/packages/lib/src/audiograph.js
+++ b/packages/lib/src/audiograph.js
@@ -136,16 +136,18 @@ export class AudioGraph {
    * Generate one [left, right] pair of audio samples
    */
   genSample(inputs) {
+    while (this.q.length > 0 && this.q[0].time <= this.playPos) {
+      // trigger due messages. q is sorted, so we only need to check q[0]
+      this.parseMsg(this.q[0].msg);
+      this.q.shift();
+    }
+
     if (!this.units.length) return [0, 0];
+
     this.playPos += 1 / 44100;
 
     const sum = [0, 0];
     for (let i = 0; i < this.units.length; i++) {
-      while (this.q.length > 0 && this.q[0].time <= this.playPos) {
-        // trigger due messages. q is sorted, so we only need to check q[0]
-        this.parseMsg(this.q[0].msg);
-        this.q.shift();
-      }
       const unit = this.units[i];
       const lvl = unit.getLevel(this.playPos);
       unit.genSample(

--- a/packages/lib/src/audiograph.js
+++ b/packages/lib/src/audiograph.js
@@ -93,6 +93,9 @@ export class AudioGraph {
       case "SCHEDULE_MSG":
         this.scheduleMessage(msg);
         break;
+      case "BATCH_MSG":
+        msg.messages.forEach((msg) => this.parseMsg(msg));
+        break;
 
       default:
         throw new TypeError(`unknown message type ${msg.type}`);

--- a/packages/lib/src/lib.js
+++ b/packages/lib/src/lib.js
@@ -759,7 +759,6 @@ export let output = registerNode("output", {
   },
 });
 
-export let exit = registerNode("exit", { internal: true });
 export let poly = registerNode("poly");
 export let PI = n(Math.PI);
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -21,9 +21,7 @@ This package allows you to use kabelsalat anywhere on the web. Example:
 .fold().mul(.6)
 .out()`;
       const { SalatRepl } = kabelsalat;
-      const repl = new SalatRepl({
-        base: "https://unpkg.com/@kabelsalat/web@0.0.7/dist/",
-      });
+      const repl = new SalatRepl();
       document.getElementById("play").onclick = () => repl.run(code);
       document.getElementById("stop").onclick = () => repl.stop();
     </script>

--- a/packages/web/src/audioview.js
+++ b/packages/web/src/audioview.js
@@ -98,12 +98,36 @@ export class AudioView {
     });
   }
 
-  setControl(id, value) {
-    this.send({
+  setControl(id, value, time) {
+    const msg = {
       type: "SET_CONTROL",
       id,
       value,
-    });
+    };
+    if (time) {
+      this.send({ type: "SCHEDULE_MSG", time, msg });
+    } else {
+      this.send(msg);
+    }
+  }
+
+  // controls: { id, value, time }[]
+  setControls(controls) {
+    const msg = {
+      type: "BATCH_MSG",
+      messages: controls.map((c) => {
+        const msg = { type: "SET_CONTROL", id: c.id, value: c.value };
+        if (c.time === undefined) {
+          return msg;
+        }
+        return {
+          type: "SCHEDULE_MSG",
+          time: c.time,
+          msg,
+        };
+      }),
+    };
+    this.send(msg);
   }
 
   async initAudioIn() {

--- a/packages/web/src/audioview.js
+++ b/packages/web/src/audioview.js
@@ -90,6 +90,14 @@ export class AudioView {
     }
   }
 
+  scheduleMessage(msg, time) {
+    this.send({
+      type: "SCHEDULE_MSG",
+      msg,
+      time,
+    });
+  }
+
   setControl(id, value) {
     this.send({
       type: "SET_CONTROL",

--- a/packages/web/src/audioview.js
+++ b/packages/web/src/audioview.js
@@ -2,57 +2,12 @@ import { assert } from "@kabelsalat/lib/src/utils.js";
 import "@kabelsalat/core/src/compiler.js"; // Node.prototype.compile
 import { MIDI, parseMidiMessage } from "@kabelsalat/lib/src/midi.js";
 import { Mouse } from "@kabelsalat/lib/src/mouse.js";
-
-// what follows are attempts at importing the worklet as a url
-// the problem: when ?url is used, the worklet.js file itself is not bundled.
-// the import "import { AudioGraph } from "./audiograph.js";" does not work when bundling iife
-// also see: https://github.com/vitejs/vite/issues/6757
-
-// /assets/worklet-FAueYngB.js
-// iife: DOMException: The user aborted a request.
-// mjs: works
 import workletUrl from "./worklet.js?worker&url";
-
-// ae(t){return new Worker("/assets/worklet-FAueYngB.js",{name:t?.name})}
-// iife: DOMException: The user aborted a request.
-// mjs: DOMException: The user aborted a request.
-//import workletUrl from "./worklet.js?worker";
-
-// data:text/javascript;base64,aW1wb3.....
-// iife: TypeError: Failed to resolve module specifier "./audiograph.js". Invalid relative url or base scheme isn't hierarchical.
-// mjs: TypeError: Failed to resolve module specifier "./audiograph.js". Invalid relative url or base scheme isn't hierarchical.
-//import workletUrl from "./worklet.js?url";
-
-// workletUrl.toString() = data:text/javascript;base64,aW1wb3.....
-// iife: TypeError: Failed to resolve module specifier "./audiograph.js". Invalid relative url or base scheme isn't hierarchical.
-// mjs: TypeError: Failed to resolve module specifier "./audiograph.js". Invalid relative url or base scheme isn't hierarchical.
-//const workletUrl = new URL("./worklet.js", import.meta.url);
-
-// potential solutions:
-// https://github.com/vitejs/vite/issues/15431#issuecomment-1870052169 // didn't work:
-
-/* const modules = import.meta.glob(["./worklet.js"]);
-// get the path of the built module.
-const importPathRegex = /import\(['"]([^'"]+)['"]\)/;
-const importStatement = Object.values(modules)[0].toString();
-console.log("importStatement", importStatement);
-const match = importStatement.match(importPathRegex);
-let workletUrl = "";
-if (match) {
-  const path = match[1];
-  workletUrl = path;
-  } */
-
-// https://stackoverflow.com/questions/76324021/how-to-package-npm-module-with-audioworklet // not tried yet
-
-// console.log("workletUrl", workletUrl);
-
 import recorderUrl from "./recorder.js?worker&url";
 import { audioBuffersToWav } from "./wav.js";
 
 export class AudioView {
-  constructor(base = "") {
-    this.base = base;
+  constructor() {
     this.ugens = new Map();
   }
   async updateGraph(node) {
@@ -193,8 +148,8 @@ export class AudioView {
       );
     }
 
-    await this.audioCtx.audioWorklet.addModule(this.base + workletUrl);
-    await this.audioCtx.audioWorklet.addModule(this.base + recorderUrl);
+    await this.audioCtx.audioWorklet.addModule(workletUrl);
+    await this.audioCtx.audioWorklet.addModule(recorderUrl);
 
     this.audioWorklet = new AudioWorkletNode(
       this.audioCtx,

--- a/packages/web/src/repl.js
+++ b/packages/web/src/repl.js
@@ -57,7 +57,7 @@ export class SalatRepl {
     this.onToggle?.(true);
   }
   run(code) {
-    const node = repl.evaluate(code);
+    const node = this.evaluate(code);
     this.play(node);
   }
   stop() {

--- a/packages/web/src/repl.js
+++ b/packages/web/src/repl.js
@@ -4,14 +4,8 @@ import * as lib from "@kabelsalat/lib/src/lib.js";
 import { AudioView } from "./audioview.js";
 
 export class SalatRepl {
-  constructor({
-    onToggle,
-    onToggleRecording,
-    beforeEval,
-    base,
-    transpiler,
-  } = {}) {
-    this.audio = new AudioView(base);
+  constructor({ onToggle, onToggleRecording, beforeEval, transpiler } = {}) {
+    this.audio = new AudioView();
     this.onToggle = onToggle;
     this.transpiler = transpiler;
     this.onToggleRecording = onToggleRecording;

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -3,6 +3,7 @@ import { resolve } from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "./",
   plugins: [],
   build: {
     lib: {

--- a/website/src/examples.js
+++ b/website/src/examples.js
@@ -565,10 +565,10 @@ bd.add(bass).add(hat).add(sn).add(acid).add(mel).mul(0.63)
     label: "distorted guitar",
     code: `audio.fadeTime=2.5;
 
-saw([55,110,220,330]).lpf( sine(.25).range(.3,.7) )
+zaw([55,110,220,330]).lpf( sine(.25).range(.3,.7) )
 .mix(2)
 .mul(impulse(4).perc(.1).lag(.05))
-.add(x=>x.delay(saw(.01).range(.005,.02)).mul(.9))
+.add(x=>x.delay(zaw(.01).range(.005,.02)).mul(.9))
 .add(x=>x.delay(.3).mul(.7))
 .fold().mul(.6)
 .out()`,


### PR DESCRIPTION
implement basic scheduling:

- add `SCHEDULE_MSG` and `BATCH_MSG` to schedule messages at a relative time in the future
- AudioView: add optional `time` argument to `setControl` to schedule control change
- AudioView: add `setControls` to batch change controls with a single message

example:

```js
repl.audio.setControls([
  { id:'freq', time:onset, value: freq },
  { id:'gate', time:onset, value: 1 },
  { id:'gate', time:offset, value: 0 },
])
```

[full strudel example](https://strudel.cc/#aWYoIXdpbmRvdy5rYWJlbHNhbGF0KSB7CiAgY29uc3QgeyBTYWxhdFJlcGwgfSA9IGF3YWl0IGltcG9ydCgnaHR0cDovL2xvY2FsaG9zdDozMDAwL2luZGV4Lm1qcycpCiAgd2luZG93LmthYmVsc2FsYXQgPSBuZXcgU2FsYXRSZXBsKHtsb2NhbFNjb3BlOnRydWV9KTsKfQoKa2FiZWxzYWxhdC5ydW5gCmxldCBlbnYgPSBjYygnZ2F0ZScpLmFkKC4wMSwuNSkKY2MoJ2ZyZXEnKS5zYXcoKQoubHBmKGVudi5iaXBvbGFyKCkucmFuZ2UoLjIsLjY1KSwgMC4yKQoubXVsKGVudikKLmFkZCh4PT54LmRlbGF5KC4xMSkubXVsKC42KSkKLmRpdigyKQoub3V0KFswLCAxXSkKYAoKCiQ6IG4ocnVuKDgpKQogIC5jaG9yZCgiPEYjbTcgRl43IzExPi8yIikKICAudm9pY2luZygpCiAgLy8uc29tZXRpbWVzQnkoIjEgLjVANyIseD0%2BeC5hZGQobm90ZSgtMTIpKSkKICAuc3ViKG5vdGUoMTIpKQogIC5vblRyaWdnZXIoKF8sIGhhcCwgY3QsIGNwcywgdCkgPT4gewogICAgY29uc3Qgb25zZXQgPSB0LWN0OwogICAgY29uc3Qgb2Zmc2V0ID0gb25zZXQgKyAuMTsKICAgIGNvbnN0IGZyZXEgPSBnZXRGcmVxdWVuY3koaGFwKQogICAga2FiZWxzYWxhdC5hdWRpby5zZXRDb250cm9scyhbCiAgICAgIHsgaWQ6J2ZyZXEnLCB0aW1lOm9uc2V0LCB2YWx1ZTogZnJlcSB9LAogICAgICB7IGlkOidnYXRlJywgdGltZTpvbnNldCwgdmFsdWU6IDEgfSwKICAgICAgeyBpZDonZ2F0ZScsIHRpbWU6b2Zmc2V0LCB2YWx1ZTogMCB9LAogICAgXSkKfSkKCl8kOiBzKCJiZCo0LCBbLSBoaF0qNCIpLmJhbmsoJ1JvbGFuZFRSOTA5Jyk%3D)

optimize package for integration (tested with strudel):
- SalatRepl: add localScope flag (opt in) to avoid global scope pollution. It's needed to avoid name collisions with strudel (like `n`)
- SalatRepl: remove base option, as worklet loading is now relative, inspired by https://github.com/tidalcycles/strudel/pull/1129 -> this also means no prebuild step is needed in the flok integration (hopefully)