### PR TITLE
Patterns

### DIFF
--- a/packages/strudel/nanostrudel.mjs
+++ b/packages/strudel/nanostrudel.mjs
@@ -1,0 +1,242 @@
+export class Pattern {
+  constructor(query) {
+    this.query = query;
+  }
+  // part is the region of the hap that is active during the query
+  queryWithParts(a, b) {
+    return this.query(a, b).map((hap) => ({
+      ...hap,
+      _a: Math.max(hap.a, a),
+      _b: Math.min(hap.b, b),
+    }));
+  }
+}
+export const P = (q) => new Pattern(q);
+
+export const cycle = (callback) =>
+  P((a, b) => {
+    a = Math.floor(a);
+    b = Math.ceil(b);
+    let bag = [];
+    while (a < b) {
+      bag = bag.concat(callback(a, a + 1));
+      a++;
+    }
+    return bag;
+  });
+
+export const repeat = (value) => cycle((a, b) => [{ a, b, value }]);
+export const nest = (value, a, b) => {
+  if (value instanceof Pattern) {
+    return value.query(a, b);
+  }
+  return [{ a, b, value }];
+};
+
+export const cat = (...values) =>
+  cycle((a, b) => {
+    let value = values[a % values.length];
+    return nest(value, a, b);
+  });
+
+export const stack = (...values) =>
+  cycle((a, b) => values.map((value) => nest(value, a, b)).flat());
+
+export const seq = (...values) => fast(values.length, cat(...values));
+
+export function minifyArgs(args) {
+  return args.map((arg) => {
+    if (typeof arg === "string") {
+      return mini(arg);
+    }
+    return arg;
+  });
+}
+
+export const registerPattern = (name, fn) => {
+  //let q = (...args) => patternifyArgs(fn, args);
+  let q = (...args) => fn(...minifyArgs(args));
+  Pattern.prototype[name] = function (...args) {
+    return q(...args, this);
+  };
+  String.prototype[name] = function (...args) {
+    return q(...args, mini(this));
+  };
+  return q;
+};
+
+export const fast = registerPattern("fast", (factor, pat) =>
+  P((a, b) =>
+    pat.query(a * factor, b * factor).map((hap) => ({
+      a: hap.a / factor,
+      b: hap.b / factor,
+      value: hap.value,
+    }))
+  )
+);
+
+export const slow = registerPattern("slow", (factor, pat) =>
+  fast(1 / factor, pat)
+);
+
+export const firstOf = registerPattern("firstOf", (n, fn, pat) =>
+  cycle((a, b) => (a % n === 0 ? fn(pat) : pat).query(a, b))
+);
+export const lastOf = registerPattern("lastOf", (n, fn, pat) =>
+  cycle((a, b) => (a % n === n - 1 ? fn(pat) : pat).query(a, b))
+);
+
+// value ops
+export const withValue = registerPattern("withValue", (fn, pat) =>
+  P((a, b) => pat.query(a, b).map((hap) => ({ ...hap, value: fn(hap.value) })))
+);
+
+export const add = registerPattern("add", (n, pat) =>
+  pat.withValue((v) => v + n)
+);
+export const sub = registerPattern("sub", (n, pat) =>
+  pat.withValue((v) => v - n)
+);
+export const mul = registerPattern("mul", (n, pat) =>
+  pat.withValue((v) => v * n)
+);
+export const div = registerPattern("div", (n, pat) =>
+  pat.withValue((v) => v / n)
+);
+export const mod = registerPattern("mod", (n, pat) =>
+  pat.withValue((v) => v % n)
+);
+
+export const reify = (value) =>
+  value instanceof Pattern ? value : repeat(value);
+
+// parser
+
+let token_types = {
+  open_cat: /^\</,
+  close_cat: /^\>/,
+  open_seq: /^\[/,
+  close_seq: /^\]/,
+  plain: /^[a-zA-Z0-9\.\#\-]+/,
+};
+function next_token(code) {
+  for (let type in token_types) {
+    const match = code.match(token_types[type]);
+    if (match) {
+      return { type, value: match[0] };
+    }
+  }
+  throw new Error(`could not match "${code}"`);
+}
+
+function tokenize(code) {
+  let tokens = [];
+  while (code.length > 0) {
+    code = code.trim();
+    const token = next_token(code);
+    code = code.slice(token.value.length);
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+class Parser {
+  parse(code) {
+    this.tokens = tokenize(code);
+    const args = this.parse_args();
+    if (args.length > 1) {
+      // "a b c" === "[a b c]"
+      return { type: "seq", args };
+    }
+    return args[0];
+  }
+  consume(type) {
+    const token = this.tokens.shift();
+    if (token.type !== type) {
+      throw new Error(`expected token type ${type}, got ${token.type}`);
+    }
+    return token;
+  }
+  parse_expr() {
+    let next = this.tokens[0]?.type;
+    if (next === "open_cat") {
+      return this.parse_cat();
+    }
+    if (next === "open_seq") {
+      return this.parse_seq();
+    }
+    if (next === "plain") {
+      return this.consume("plain");
+    }
+    throw new Error(
+      `unexpected token "${this.tokens[0].value}" of type ${this.tokens[0].type}`
+    );
+  }
+  parse_args(close_type) {
+    const args = [];
+    while (this.tokens[0]?.type !== close_type) {
+      args.push(this.parse_expr());
+    }
+    return args;
+  }
+  parse_seq() {
+    this.consume("open_seq");
+    const args = this.parse_args("close_seq");
+    this.consume("close_seq");
+    return { type: "seq", args };
+  }
+  parse_cat() {
+    this.consume("open_cat");
+    const args = this.parse_args("close_cat");
+    this.consume("close_cat");
+    return { type: "cat", args };
+  }
+}
+
+function patternifyTree(tree) {
+  if (tree.type === "cat") {
+    const args = tree.args.map((arg) => patternifyTree(arg));
+    return cat(...args);
+  }
+  if (tree.type === "seq") {
+    const args = tree.args.map((arg) => patternifyTree(arg));
+    return seq(...args);
+  }
+  if (tree.type === "plain") {
+    return tree.value;
+  }
+}
+
+const parser = new Parser();
+
+export let mini = (code) => {
+  const tree = parser.parse(code);
+  const pat = patternifyTree(tree);
+  return reify(pat);
+};
+
+export const $ = (ministring) => {
+  ministring = Array.isArray(ministring) ? ministring[0] : ministring;
+  const pat = mini(ministring);
+  const latency = 0.1;
+  let f = 4,
+    dur = 1 / f;
+  let phi;
+  return impulse(f).signal((t, id) => {
+    let begin = phi || t,
+      end = t + dur;
+    const haps = pat.query(begin, end);
+    phi = end;
+    const events = haps
+      .filter((hap) => hap.a >= t && hap.a < end)
+      .map((hap) => ({
+        id,
+        value: Number(hap.value),
+        time: hap.a + latency - t,
+      }));
+    if (events.length) {
+      // console.log(t.toFixed(2), begin.toFixed(2), end.toFixed(2), events);
+      repl.audio.setControls(events);
+    }
+  });
+};

--- a/packages/strudel/package.json
+++ b/packages/strudel/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@kabelsalat/strudel",
+  "version": "0.3.0",
+  "type": "module",
+  "module": "nanostrudel.mjs",
+  "main": "nanostrudel.mjs",
+  "author": "Felix Roos <flix91@gmail.com>",
+  "license": "AGPL-3.0-or-later",
+  "scripts": {},
+  "devDependencies": {
+    "vite": "^5.2.0"
+  },
+  "dependencies": {
+    "@kabelsalat/core": "workspace:*"
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@kabelsalat/core": "workspace:*",
+    "@kabelsalat/strudel": "workspace:*",
     "@kabelsalat/lib": "workspace:*"
   },
   "devDependencies": {

--- a/packages/web/src/repl.js
+++ b/packages/web/src/repl.js
@@ -17,12 +17,10 @@ export class SalatRepl {
     this.onToggleRecording = onToggleRecording;
     this.beforeEval = beforeEval;
     this.localScope = localScope;
+    const scope = { ...core, ...lib, ...compiler, repl: this };
     if (typeof window !== "undefined") {
       if (!localScope) {
-        Object.assign(globalThis, core);
-        Object.assign(globalThis, lib);
-        Object.assign(globalThis, compiler);
-        Object.assign(globalThis, { repl: this });
+        Object.assign(globalThis, scope);
       }
       // update state when sliders are moved
       // TODO: remove listener?
@@ -41,12 +39,14 @@ export class SalatRepl {
   }
 
   evaluate(code) {
+    const innerScope = {
+      audio: this.audio,
+      addUgen: this.registerUgen.bind(this),
+      repl: this,
+    };
     if (!this.localScope) {
       // re-assign instance specific scope before each eval..
-      Object.assign(globalThis, { audio: this.audio });
-      Object.assign(globalThis, {
-        addUgen: this.registerUgen.bind(this),
-      });
+      Object.assign(globalThis, innerScope);
     }
     let transpiled;
     if (this.transpiler) {
@@ -58,12 +58,8 @@ export class SalatRepl {
     let scope;
     if (this.localScope) {
       scope = {
-        ...core,
-        ...lib,
-        ...compiler,
-        audio: this.audio,
-        addUgen: this.registerUgen.bind(this),
-        repl: this,
+        ...scope,
+        ...innerScope,
       };
     }
     return core.evaluate(transpiled.output, scope);

--- a/packages/web/src/repl.js
+++ b/packages/web/src/repl.js
@@ -1,6 +1,7 @@
 import * as core from "@kabelsalat/core/src/index.js";
 import * as compiler from "@kabelsalat/core/src/compiler.js";
 import * as lib from "@kabelsalat/lib/src/lib.js";
+import * as strudel from "@kabelsalat/strudel";
 import { AudioView } from "./audioview.js";
 
 export class SalatRepl {
@@ -17,7 +18,7 @@ export class SalatRepl {
     this.onToggleRecording = onToggleRecording;
     this.beforeEval = beforeEval;
     this.localScope = localScope;
-    const scope = { ...core, ...lib, ...compiler, repl: this };
+    const scope = { ...core, ...lib, ...compiler, ...strudel, repl: this };
     if (typeof window !== "undefined") {
       if (!localScope) {
         Object.assign(globalThis, scope);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,16 @@ importers:
         specifier: ^5.2.0
         version: 5.3.1
 
+  packages/strudel:
+    dependencies:
+      '@kabelsalat/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      vite:
+        specifier: ^5.2.0
+        version: 5.3.1
+
   packages/transpiler:
     dependencies:
       acorn:
@@ -107,6 +117,9 @@ importers:
       '@kabelsalat/lib':
         specifier: workspace:*
         version: link:../lib
+      '@kabelsalat/strudel':
+        specifier: workspace:*
+        version: link:../strudel
     devDependencies:
       vite:
         specifier: ^5.2.0


### PR DESCRIPTION
a poc for a "strudel" pattern integration. strudel in quotes, because the current implementation is not using strudel, but a very simplified version based on [idlecycles](https://github.com/felixroos/idlecycles/tree/main).
Only mini notation is supported, with most operations not working.

The `$` function converts mini notation to a [signal](https://github.com/felixroos/kabelsalat/pull/56) :

```js
$`220 330 [440 550]`
.lag(.1)
.sine()
.add(x=>x.delay(.2).mul(.5))
.out()
```

While patterns in strudel/tidal are "aligned" into a single pattern at the end, this integration queries each pattern individually, so alignment is not needed. It is similar to how strudel is inserted into hydra (using the P function).

Some follow up questions: 
- how to handle polyphony? (using , inside mini notation), => maybe like midifreq/midigate?
- how to integrate controls? e.g. to use `n` and `scale`.
- how to avoid naming collisions when adding strudel functions to the scope..
- should strudel even handle more, or should this be done in kabelsalat land?

This integration is kind of the opposite of [kabelsalat in strudel](https://strudel.cc/?9aIYrCHXezo8)..