### PR TITLE
use vite-plugin-bundle-audioworklet

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,6 +19,7 @@
     "@kabelsalat/lib": "workspace:*"
   },
   "devDependencies": {
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vite-plugin-bundle-audioworklet": "0.1.1"
   }
 }

--- a/packages/web/src/audioview.js
+++ b/packages/web/src/audioview.js
@@ -2,8 +2,8 @@ import { assert } from "@kabelsalat/lib/src/utils.js";
 import "@kabelsalat/core/src/compiler.js"; // Node.prototype.compile
 import { MIDI, parseMidiMessage } from "@kabelsalat/lib/src/midi.js";
 import { Mouse } from "@kabelsalat/lib/src/mouse.js";
-import workletUrl from "./worklet.js?worker&url";
-import recorderUrl from "./recorder.js?worker&url";
+import workletUrl from "./worklet.js?audioworklet";
+import recorderUrl from "./recorder.js?audioworklet";
 import { audioBuffersToWav } from "./wav.js";
 import { register } from "@kabelsalat/core";
 import * as js from "@kabelsalat/lib/src/lang/js.js";

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import { resolve } from "path";
+import bundleAudioWorkletPlugin from "vite-plugin-bundle-audioworklet";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,7 +12,7 @@ export default defineConfig({
   // both don't work out of the box (404), but the latter can be worked around by copying the file to public/assets
   // the former doesn't work with copying because it seems node_modules is filtered out when serving files
   // all of this is relevant for esm, in cjs it seems to work with base, not sure what happens without...
-  plugins: [],
+  plugins: [bundleAudioWorkletPlugin()],
   build: {
     lib: {
       name: "kabelsalat",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vite:
         specifier: ^5.2.0
         version: 5.3.1
+      vite-plugin-bundle-audioworklet:
+        specifier: 0.1.1
+        version: 0.1.1
 
   test:
     dependencies:
@@ -194,6 +197,9 @@ importers:
       vite:
         specifier: ^5.2.0
         version: 5.3.1
+      vite-plugin-bundle-audioworklet:
+        specifier: 0.1.1
+        version: 0.1.1
       vite-plugin-solid:
         specifier: ^2.10.2
         version: 2.10.2(solid-js@1.8.18)(vite@5.3.1)
@@ -4073,6 +4079,9 @@ packages:
     resolution: {integrity: sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-plugin-bundle-audioworklet@0.1.1:
+    resolution: {integrity: sha512-CYZArbUk7GxhYsMjibfbkqy6O0JK3wUo2WARWbwtYn+IAVHdxe1CGMSis9+vq3GoxhhdRaUsBq1bFrtfnR0uIw==}
 
   vite-plugin-solid@2.10.2:
     resolution: {integrity: sha512-AOEtwMe2baBSXMXdo+BUwECC8IFHcKS6WQV/1NEd+Q7vHPap5fmIhLcAzr+DUJ04/KHx/1UBU0l1/GWP+rMAPQ==}
@@ -9050,6 +9059,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-plugin-bundle-audioworklet@0.1.1: {}
 
   vite-plugin-solid@2.10.2(solid-js@1.8.18)(vite@5.3.1):
     dependencies:

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,11 +1,14 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import solidJs from "@astrojs/solid-js";
-
+import bundleAudioWorkletPlugin from "vite-plugin-bundle-audioworklet";
 import mdx from "@astrojs/mdx";
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [tailwind(), solidJs(), mdx()],
   base: "/",
+  vite: {
+    plugins: [bundleAudioWorkletPlugin()],
+  },
 });

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "vite": "^5.2.0",
-    "vite-plugin-solid": "^2.10.2"
+    "vite-plugin-solid": "^2.10.2",
+    "vite-plugin-bundle-audioworklet": "0.1.1"
   }
 }


### PR DESCRIPTION
similar to https://github.com/tidalcycles/strudel/pull/1338 , this PR uses `vite-plugin-bundle-audioworklet` to bundle the worklet without the need to copy paste the files around when consuming the package