### PR TITLE
Connect SalatRepl to other destinations and contexts

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,7 +1,8 @@
 # @kabelsalat/web
 
-This package allows you to use kabelsalat anywhere on the web. Example:
+This package allows you to use kabelsalat anywhere on the web. 
 
+## Using an inline script
 ```html
 <!DOCTYPE html>
 <html>
@@ -28,3 +29,29 @@ This package allows you to use kabelsalat anywhere on the web. Example:
   </body>
 </html>
 ```
+
+## Using ES6 import:
+```js
+import { SalatRepl } from '@kabelsalat/web'
+```
+
+## Connecting the Repl to other outputs
+By default, the Repl will create an audio context and connect to its destination. If you want to connect the Repl to another component, simply pass an AudioNode on instantiation:
+```js
+import { SalatRepl } from '@kabelsalat/web'
+
+// create an audio context
+const audioCtx = new AudioContext({
+  latencyHint: "interactive",
+  sampleRate: 44100,
+})
+
+// create an abritrary audio node
+const gain = new GainNode(audioCtx)
+// connect to the destination
+gain.connect(audioCtx.destination);
+
+const repl = new SalatRepl({outputNode: gain})
+```
+
+

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -36,22 +36,23 @@ import { SalatRepl } from '@kabelsalat/web'
 ```
 
 ## Connecting the Repl to other outputs
-By default, the Repl will create an audio context and connect to its destination. If you want to connect the Repl to another component, simply pass an AudioNode on instantiation:
-```js
-import { SalatRepl } from '@kabelsalat/web'
+Connecting the Repl to other audio nodes:
 
-// create an audio context
+By default, SalatRepl creates an AudioContext and connects to its destination. To connect the Repl to a different audio node (e.g., GainNode, BiquadFilterNode), pass the desired AudioNode as the 'outputNode' parameter during instantiation.
+
+```js
+// Create a new AudioContext with standard settings
 const audioCtx = new AudioContext({
   latencyHint: "interactive",
   sampleRate: 44100,
-})
+});
 
-// create an abritrary audio node
-const gain = new GainNode(audioCtx)
-// connect to the destination
+// Create a GainNode to adjust volume levels
+const gain = new GainNode(audioCtx);
+
+// Connect the GainNode to the AudioContext's destination (e.g., speakers)
 gain.connect(audioCtx.destination);
 
-const repl = new SalatRepl({outputNode: gain})
+// Instantiate the Repl, passing the GainNode as the output node
+const repl = new SalatRepl({ outputNode: gain });
 ```
-
-

--- a/packages/web/src/audioview.js
+++ b/packages/web/src/audioview.js
@@ -240,10 +240,10 @@ export class AudioView {
     this.recorder?.disconnect();
     this.recorder = null;
 
-    // if a the output node is set, we don't want to close the context
+    // if a custom output node has been set, keep the audio context alive to avoid interfering with the user's signal chain
     !this.outputNode && this.audioCtx?.close();
     
-    // but we will nullify it to ensure the init method will be called again
+    // but nullify it at our end so that the init() method runs again
     this.audioCtx = null;
   }
 

--- a/packages/web/src/repl.js
+++ b/packages/web/src/repl.js
@@ -10,8 +10,10 @@ export class SalatRepl {
     beforeEval,
     transpiler,
     localScope = false,
+    outputNode = null,
   } = {}) {
-    this.audio = new AudioView();
+    this.outputNode = outputNode;
+    this.audio = new AudioView(this.outputNode);
     this.onToggle = onToggle;
     this.transpiler = transpiler;
     this.onToggleRecording = onToggleRecording;


### PR DESCRIPTION
Hi!

A suggestion for giving the user the power to connect the SalatRepl with their own signal chain. We pass any kind of AudioNode on instantiation, it sets the audio context based on the node, then connects to it each time we run some code.

Responding to [this issue](https://github.com/felixroos/kabelsalat/issues/73).

Updated Readme. 