### PR TITLE
Add midi velocity function

### DIFF
--- a/packages/lib/src/audiograph.js
+++ b/packages/lib/src/audiograph.js
@@ -259,16 +259,24 @@ class Unit {
         node.type === "midigate" &&
         (node.channel === -1 || node.channel === channel)
     );
+    const midivelocities = this.nodes.filter(
+      (node) =>
+        node.type === "midivelocity" &&
+        (node.channel === -1 || node.channel === channel)
+    );
 
     if (velocity > 0) {
       // get free voice or steal one
       let freqNode = midifreqs.find((node) => node.isFree()) || midifreqs[0];
       let gateNode = midigates.find((node) => node.isFree()) || midigates[0];
+      let velocityNode = midivelocities.find((node) => node.isFree()) || midivelocities[0];
       freqNode?.noteOn(note, velocity);
       gateNode?.noteOn(note, velocity);
+      velocityNode?.noteOn(note, velocity);
     } else {
       midifreqs.find((node) => node.note === note)?.noteOff();
       midigates.find((node) => node.note === note)?.noteOff();
+      midivelocities.find((node) => node.note === note)?.noteOff();
     }
   }
 

--- a/packages/lib/src/lib.js
+++ b/packages/lib/src/lib.js
@@ -5,6 +5,7 @@ import {
   register,
   module,
   node,
+  compile,
 } from "@kabelsalat/core";
 import * as js from "./lang/js.js";
 import * as c from "./lang/c.js";
@@ -457,6 +458,15 @@ export let midigate = registerNode("midigate", {
     "outputs gate of midi note in. Multiple instances will do voice allocation",
   examples: [`midigate().lag(1).mul(sine(220)).out()`],
   ins: [{ name: "channel", default: -1 }],
+  compile: ({ vars: [channel = -1], ...meta }) =>
+    langs[meta.lang].defUgen(meta, channel),
+});
+export let midivelocity = registerNode("midivelocity", {
+  ugen: "MidiVelocity",
+  tags: ["external", "midi"],
+  description: "outputs velocity of midi note in. Multiple instances will do voice allocation",
+  examples: [`midigate().ar(0.01,0.2).mul(saw(midifreq())).mul(midivelocity()).mul(.8).out()`],
+  ins: [{ name: "channel", default: -1}],
   compile: ({ vars: [channel = -1], ...meta }) =>
     langs[meta.lang].defUgen(meta, channel),
 });

--- a/packages/lib/src/midi.js
+++ b/packages/lib/src/midi.js
@@ -76,6 +76,7 @@ export function parseMidiMessage(msg) {
   if (msgType == 0x90 && msg.length == 3) {
     let note = msg[1];
     let velocity = msg[2];
+    velocity = (velocity / 127) * 2 - 1; // to bipolar
     return { type: "NOTE_ON", channel, note, velocity };
   }
 

--- a/packages/lib/src/midi.js
+++ b/packages/lib/src/midi.js
@@ -75,8 +75,7 @@ export function parseMidiMessage(msg) {
   // Note on
   if (msgType == 0x90 && msg.length == 3) {
     let note = msg[1];
-    let velocity = msg[2];
-    velocity = (velocity / 127) * 2 - 1; // to bipolar
+    let velocity = msg[2] / 127; // bring value between 0 and 1
     return { type: "NOTE_ON", channel, note, velocity };
   }
 

--- a/packages/lib/src/ugens.js
+++ b/packages/lib/src/ugens.js
@@ -687,6 +687,23 @@ export class MidiIn extends AudioNode {
         assert(false);
     }
   }
+
+  getVelocity() {
+    switch (this.gateState) {
+      case "pretrig":
+        this.gateState = "on";
+        return 0;
+
+      case "on":
+        return this.velocity;
+
+      case "off":
+        return this.velocity;
+
+      default:
+        assert(false);
+    }
+  }
 }
 
 /**
@@ -711,6 +728,17 @@ export class MidiFreq extends MidiIn {
   update(channel) {
     this.channel = channel;
     return this.getFreq();
+  }
+}
+
+export class MidiVelocity extends MidiIn {
+  constructor(id, state, sampleRate, send) {
+    super(id, state, sampleRate, send);
+    this.type = "midivelocity";
+  }
+  update(channel) {
+    this.channel = channel;
+    return this.getVelocity();
   }
 }
 

--- a/packages/lib/src/ugens.js
+++ b/packages/lib/src/ugens.js
@@ -640,6 +640,7 @@ export class MidiIn extends AudioNode {
   noteOn(note, velocity) {
     if (velocity > 0) {
       this.note = note;
+      this.velocity = velocity;
       this.freq = 2 ** ((note - 69) / 12) * 440;
       this.gateState = "pretrig";
     } else {


### PR DESCRIPTION
- now you can use `midivelocity()` similar to `midigate()` and `midifreq()` like this for example:

```midigate(1).ar(0.01,0.2).mul(saw(midifreq(1))).mul(midivelocity(1)).mul(.8).out()```

note: fork doesn't work yet with midivelocity(), don't know why.